### PR TITLE
Add GemTracker plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# mc_gemtracker
+# GemTracker
+
+A simple Bukkit plugin that tracks player gems based on active playtime.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.gemtracker'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+    maven {
+        name = 'spigot'
+        url = uri('https://hub.spigotmc.org/nexus/content/repositories/snapshots/')
+    }
+}
+
+dependencies {
+    compileOnly 'org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT'
+    testImplementation 'junit:junit:4.13.2'
+}
+
+test {
+    useJUnit()
+}
+
+jar {
+    manifest {
+        attributes 'Implementation-Title': project.name,
+                   'Implementation-Version': project.version,
+                   'Main-Class': 'com.gemtracker.GemTrackerPlugin'
+    }
+}

--- a/src/main/java/com/gemtracker/GemCommand.java
+++ b/src/main/java/com/gemtracker/GemCommand.java
@@ -1,0 +1,84 @@
+package com.gemtracker;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+
+/**
+ * Command executor for /gems.
+ */
+public class GemCommand implements CommandExecutor, TabCompleter {
+    private final GemManager gemManager;
+
+    public GemCommand(GemManager gemManager) {
+        this.gemManager = gemManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            if (!(sender instanceof Player)) {
+                sender.sendMessage("Usage: /gems <player>");
+                return true;
+            }
+            Player player = (Player) sender;
+            int gems = gemManager.getGems(player.getUniqueId());
+            sender.sendMessage("You have " + gems + " gems.");
+            return true;
+        }
+
+        if (args.length == 1) {
+            OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
+            int gems = gemManager.getGems(target.getUniqueId());
+            sender.sendMessage(target.getName() + " has " + gems + " gems.");
+            return true;
+        }
+
+        if (args.length >= 3) {
+            if (!sender.hasPermission("gemtracker.admin")) {
+                sender.sendMessage("You do not have permission.");
+                return true;
+            }
+            String sub = args[0];
+            OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
+            UUID uuid = target.getUniqueId();
+            int amount;
+            try {
+                amount = Integer.parseInt(args[2]);
+            } catch (NumberFormatException ex) {
+                sender.sendMessage("Amount must be a number");
+                return true;
+            }
+            if (sub.equalsIgnoreCase("set")) {
+                gemManager.setGems(uuid, amount);
+                sender.sendMessage("Set " + target.getName() + "'s gems to " + amount);
+            } else if (sub.equalsIgnoreCase("add")) {
+                gemManager.addGems(uuid, amount);
+                sender.sendMessage("Added " + amount + " gems to " + target.getName());
+            } else {
+                sender.sendMessage("Unknown subcommand");
+            }
+            return true;
+        }
+
+        sender.sendMessage("Usage: /gems [player] | set <player> <amount> | add <player> <amount>");
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            return StringUtil.copyPartialMatches(args[0], Arrays.asList("set", "add"), Arrays.asList());
+        }
+        return Arrays.asList();
+    }
+}

--- a/src/main/java/com/gemtracker/GemManager.java
+++ b/src/main/java/com/gemtracker/GemManager.java
@@ -1,0 +1,117 @@
+package com.gemtracker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+/**
+ * Handles gem storage, loading and saving for players.
+ */
+public class GemManager {
+    private final GemTrackerPlugin plugin;
+    private final File dataFolder;
+    private final Map<UUID, Integer> gems = new HashMap<>();
+    private final Map<UUID, Long> lastActive = new HashMap<>();
+
+    public GemManager(GemTrackerPlugin plugin) {
+        this.plugin = plugin;
+        this.dataFolder = new File(plugin.getDataFolder(), "playerdata");
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+        }
+    }
+
+    /** Load gems for a player from disk. */
+    public void loadGems(UUID uuid) {
+        File file = new File(dataFolder, uuid.toString() + ".yml");
+        if (file.exists()) {
+            FileConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+            gems.put(uuid, cfg.getInt("gems"));
+        } else {
+            gems.put(uuid, 0);
+        }
+        lastActive.put(uuid, System.currentTimeMillis());
+    }
+
+    /** Save gems for a player to disk. */
+    public void saveGems(UUID uuid) {
+        Integer amount = gems.get(uuid);
+        if (amount == null) return;
+        File file = new File(dataFolder, uuid.toString() + ".yml");
+        FileConfiguration cfg = new YamlConfiguration();
+        cfg.set("gems", amount);
+        try {
+            cfg.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Could not save data for " + uuid + ": " + e.getMessage());
+        }
+    }
+
+    /** Save all loaded player data. */
+    public void saveAll() {
+        for (UUID uuid : gems.keySet()) {
+            saveGems(uuid);
+        }
+    }
+
+    /** Get gems for a player (loads from disk if not loaded). */
+    public int getGems(UUID uuid) {
+        if (!gems.containsKey(uuid)) {
+            loadGems(uuid);
+        }
+        return gems.getOrDefault(uuid, 0);
+    }
+
+    /** Set gems for a player. */
+    public void setGems(UUID uuid, int amount) {
+        gems.put(uuid, amount);
+    }
+
+    /** Add gems to a player. */
+    public void addGems(UUID uuid, int amount) {
+        gems.put(uuid, getGems(uuid) + amount);
+    }
+
+    /** Record activity timestamp for a player. */
+    public void markActive(UUID uuid) {
+        lastActive.put(uuid, System.currentTimeMillis());
+    }
+
+    /** Start scheduled tasks for awarding gems and showing action bar. */
+    public void startTasks() {
+        // Award gems every minute
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                long now = System.currentTimeMillis();
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    UUID uuid = player.getUniqueId();
+                    long last = lastActive.getOrDefault(uuid, now);
+                    if (now - last <= 60000) {
+                        addGems(uuid, 2);
+                    }
+                }
+            }
+        }.runTaskTimer(plugin, 1200L, 1200L); // every 60s
+
+        // Send action bar every 5 seconds
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    int count = getGems(player.getUniqueId());
+                    player.sendActionBar("Gems: " + count);
+                }
+            }
+        }.runTaskTimer(plugin, 100L, 100L); // every 5s
+    }
+}

--- a/src/main/java/com/gemtracker/GemTrackerPlugin.java
+++ b/src/main/java/com/gemtracker/GemTrackerPlugin.java
@@ -1,0 +1,32 @@
+package com.gemtracker;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Main plugin class for GemTracker.
+ */
+public class GemTrackerPlugin extends JavaPlugin {
+    private GemManager gemManager;
+
+    @Override
+    public void onEnable() {
+        // Initialize manager and register listeners/commands
+        this.gemManager = new GemManager(this);
+        getServer().getPluginManager().registerEvents(new PlayerListener(gemManager), this);
+        GemCommand command = new GemCommand(gemManager);
+        getCommand("gems").setExecutor(command);
+        getCommand("gems").setTabCompleter(command);
+
+        // Start recurring tasks
+        gemManager.startTasks();
+        getLogger().info("GemTracker enabled");
+    }
+
+    @Override
+    public void onDisable() {
+        // Save all player data
+        gemManager.saveAll();
+        getLogger().info("GemTracker disabled");
+    }
+}

--- a/src/main/java/com/gemtracker/PlayerListener.java
+++ b/src/main/java/com/gemtracker/PlayerListener.java
@@ -1,0 +1,41 @@
+package com.gemtracker;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Handles player join/quit and activity detection.
+ */
+public class PlayerListener implements Listener {
+    private final GemManager gemManager;
+
+    public PlayerListener(GemManager gemManager) {
+        this.gemManager = gemManager;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        gemManager.loadGems(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        gemManager.saveGems(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (!event.getFrom().toVector().equals(event.getTo().toVector())) {
+            gemManager.markActive(event.getPlayer().getUniqueId());
+        }
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        gemManager.markActive(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,16 @@
+name: GemTracker
+main: com.gemtracker.GemTrackerPlugin
+version: 1.0
+api-version: 1.21
+commands:
+  gems:
+    description: Gem management
+    usage: /gems
+    permission: gemtracker.use
+permissions:
+  gemtracker.use:
+    description: Allows use of /gems
+    default: true
+  gemtracker.admin:
+    description: Admin commands for /gems
+    default: op


### PR DESCRIPTION
## Summary
- add Gradle config and plugin YAML
- implement GemTracker plugin with gem tracking, commands, and event listeners
- update README

## Testing
- `gradle build` *(fails: Could not resolve dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684dc775e5e8832baf808b7f2f8f731b